### PR TITLE
Update for Lita 3.0, use Ruby whois library

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -1,0 +1,8 @@
+Documentation:
+  Enabled: false
+
+FileName:
+  Enabled: false
+
+MethodLength:
+  Max: 15

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,0 +1,8 @@
+language: ruby
+rvm:
+  - 2.0.0
+script: bundle exec rake
+before_install:
+  - gem update --system
+services:
+  - redis-server

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,0 +1,9 @@
+Pull requests are awesome!  Pull requests with tests are even more awesome!
+
+## Quick steps
+
+1. Fork the repo.
+2. Run the tests: `bundle && rake`
+3. Add a test for your change. Only refactoring and documentation changes require no new tests. If you are adding functionality or fixing a bug, it needs a test!
+4. Make the test pass.
+5. Push to your fork and submit a pull request.

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # lita-whois
 
-WHOIS handler for lita chat bot
+WHOIS handler for searching domain, TLD, IPv4, and IPv6 WHOIS records.
 
 ## Installation
 
@@ -12,11 +12,17 @@ gem "lita-whois"
 
 ## Configuration
 
-
+None
 
 ## Usage
 
-TODO: Describe the plugin's features and how to use them.
+Basics:
+```
+Lita whois example.com            - Get the WHOIS info for a domain
+Lita whois .io                    - Get the WHOIS info for a TLD
+Lita whois 8.8.8.8                - Get the WHOIS info for an IPv4 address
+Lita whois 2001:418:141e:196::fc4 - Get the WHOIS info for an IPv6 address
+```
 
 ## License
 

--- a/Rakefile
+++ b/Rakefile
@@ -1,6 +1,8 @@
-require "bundler/gem_tasks"
-require "rspec/core/rake_task"
+require 'bundler/gem_tasks'
+require 'rspec/core/rake_task'
+require 'rubocop/rake_task'
 
 RSpec::Core::RakeTask.new(:spec)
+Rubocop::RakeTask.new(:rubocop)
 
-task :default => :spec
+task default: [ :spec, :rubocop ]

--- a/lib/lita-whois.rb
+++ b/lib/lita-whois.rb
@@ -1,2 +1,10 @@
-require "cocaine"
-require "lita/handlers/whois"
+require 'lita'
+
+Lita.load_locales Dir[File.expand_path(
+    File.join('..', '..', 'locales', '*.yml'), __FILE__
+)]
+
+require 'lita/handlers/whois'
+
+require 'ipaddress'
+require 'whois'

--- a/lib/lita/handlers/whois.rb
+++ b/lib/lita/handlers/whois.rb
@@ -1,15 +1,71 @@
-require "lita"
-
 module Lita
   module Handlers
     class Whois < Handler
-        route(/^whois\s+(.+)/, :whois, help: {"whois DOMAIN" => "Get the WHOIS info for a domain."})
-        
-        def whois(response)
-          domain = response.match_data[1]
-          line = ::Cocaine::CommandLine.new("whois", ':domain')
-          response.reply(line.run(domain: domain))
+      route(
+        /^whois\s(\w+).(\w+)$/,
+        :whois_domain,
+        help: {
+          'whois example.com' => 'Get the WHOIS info for a domain'
+        }
+      )
+
+      route(
+        /^whois\s.(\w+)$/,
+        :whois_tld,
+        help: {
+          'whois .io' => 'Get the WHOIS info for a TLD'
+        }
+      )
+
+      route(
+        /^whois\s(.+)$/,
+        :whois_ip,
+        help: {
+          'whois 8.8.8.8' => 'Get the WHOIS info for an IPv4 or IPv6 address'
+        }
+      )
+
+      def whois_domain(response)
+        response.reply(lookup("#{response.matches[0][0]}." \
+                              "#{response.matches[0][1]}"))
+      end
+
+      def whois_tld(response)
+        response.reply(lookup(".#{response.matches[0][0]}"))
+      end
+
+      def whois_ip(response)
+        if IPAddress.valid? response.matches[0][0]
+          response.reply(reverse_lookup(response.matches[0][0]))
         end
+      end
+
+      private
+
+      def lookup(domain)
+        client = ::Whois::Client.new
+        record = nil
+        begin
+          record = client.lookup(domain)
+        rescue ::Whois::ServerNotFound
+          return "Cannot find a WHOIS server for #{domain}"
+        end
+
+        record.to_s
+      end
+
+      def reverse_lookup(ip)
+        client = ::Whois::Client.new
+        record = nil
+        begin
+          record = client.lookup(ip)
+        rescue ::Whois::AllocationUnknown, ::Whois::ServerNotFound,
+               ::Whois::NoInterfaceError
+          return "Cannot find a WHOIS server for #{ip}"
+        end
+
+        record.to_s
+      end
     end
 
     Lita.register_handler(Whois)

--- a/lita-whois.gemspec
+++ b/lita-whois.gemspec
@@ -1,22 +1,27 @@
 Gem::Specification.new do |spec|
   spec.name          = "lita-whois"
-  spec.version       = "0.0.5"
-  spec.authors       = ["glebtv"]
-  spec.email         = ["glebtv@gmail.com"]
+  spec.version       = "0.1.0"
+  spec.authors       = ["glebtv", "Eric Sigler"]
+  spec.email         = ["glebtv@gmail.com", "me@esigler.com"]
   spec.description   = %q{WHOIS handler for lita chat bot}
   spec.summary       = %q{WHOIS handler for lita chat bot}
   spec.homepage      = "https://github.com/glebtv/lita-whois"
   spec.license       = "MIT"
+  spec.metadata      = { "lita_plugin_type" => "handler" }
 
   spec.files         = `git ls-files`.split($/)
   spec.executables   = spec.files.grep(%r{^bin/}) { |f| File.basename(f) }
   spec.test_files    = spec.files.grep(%r{^(test|spec|features)/})
   spec.require_paths = ["lib"]
 
-  spec.add_runtime_dependency "lita", "~> 2.4"
-  spec.add_runtime_dependency "cocaine"
+  spec.add_runtime_dependency "lita", ">= 3.0"
+  spec.add_runtime_dependency "whois"
+  spec.add_runtime_dependency "ipaddress"
 
   spec.add_development_dependency "bundler", "~> 1.3"
   spec.add_development_dependency "rake"
-  spec.add_development_dependency "rspec", ">= 2.14"
+  spec.add_development_dependency "rspec", ">= 3.0.0.beta2"
+  spec.add_development_dependency "simplecov"
+  spec.add_development_dependency "coveralls"
+  spec.add_development_dependency "rubocop"
 end

--- a/locales/en.yml
+++ b/locales/en.yml
@@ -1,0 +1,4 @@
+en:
+  lita:
+    handlers:
+      whois:

--- a/spec/lita/handlers/whois_spec.rb
+++ b/spec/lita/handlers/whois_spec.rb
@@ -1,4 +1,122 @@
-require "spec_helper"
+require 'spec_helper'
 
 describe Lita::Handlers::Whois, lita_handler: true do
+  it { routes_command('whois example.com').to(:whois_domain) }
+  it { routes_command('whois .io').to(:whois_tld) }
+  it { routes_command('whois 8.8.8.8').to(:whois_ip) }
+  it { routes_command('whois 2001:418:141e:196::fc4').to(:whois_ip) }
+
+  describe '#whois_domain' do
+    let(:domain_good) do
+      client = double
+      expect(client).to receive(:lookup) { 'Generic response example.com' }
+      client
+    end
+
+    let(:domain_bad) do
+      client = double
+      expect(client).to receive(:lookup) { 'Bad domain asdfasfldjf.com' }
+      client
+    end
+
+    let(:domain_err) do
+      client = double
+      expect(client).to receive(:lookup).and_raise(Whois::ServerNotFound)
+      client
+    end
+
+    it 'shows a record when the domain exists' do
+      expect(Whois::Client).to receive(:new) { domain_good }
+      send_command('whois example.com')
+      expect(replies.last).to eq('Generic response example.com')
+    end
+
+    it 'shows an error when the domain is not registered' do
+      expect(Whois::Client).to receive(:new) { domain_bad }
+      send_command('whois asdfasfldjf.com')
+      expect(replies.last).to eq('Bad domain asdfasfldjf.com')
+    end
+
+    it 'shows an error when the domain does not have a WHOIS' do
+      expect(Whois::Client).to receive(:new) { domain_err }
+      send_command('whois asdf.sdf')
+      expect(replies.last).to eq('Cannot find a WHOIS server for asdf.sdf')
+    end
+  end
+
+  describe '#whois_tld' do
+    let(:tld_good) do
+      client = double
+      expect(client).to receive(:lookup) { 'Generic TLD response .io' }
+      client
+    end
+
+    let(:tld_bad) do
+      client = double
+      expect(client).to receive(:lookup) { 'Invalid TLD response .wtf' }
+      client
+    end
+
+    it 'shows a record when the tld exists' do
+      expect(Whois::Client).to receive(:new) { tld_good }
+      send_command('whois .io')
+      expect(replies.last).to eq('Generic TLD response .io')
+    end
+
+    it 'shows an error when the tld does not exist' do
+      expect(Whois::Client).to receive(:new) { tld_bad }
+      send_command('whois .wtf')
+      expect(replies.last).to eq('Invalid TLD response .wtf')
+    end
+  end
+
+  describe '#whois_ipv4' do
+    let(:ipv4_good) do
+      client = double
+      expect(client).to receive(:lookup) { 'Generic IPv4 response 8.8.8.8' }
+      client
+    end
+
+    let(:ipv4_err) do
+      client = double
+      expect(client).to receive(:lookup).and_raise(Whois::ServerNotFound)
+      client
+    end
+
+    let(:ipv6_good) do
+      client = double
+      expect(client).to receive(:lookup) { 'IPv6 resp 2001:418:141e:196::fc4' }
+      client
+    end
+
+    let(:ipv6_err) do
+      client = double
+      expect(client).to receive(:lookup).and_raise(Whois::ServerNotFound)
+      client
+    end
+
+    it 'shows results for the IPv4 address' do
+      expect(Whois::Client).to receive(:new) { ipv4_good }
+      send_command('whois 8.8.8.8')
+      expect(replies.last).to eq('Generic IPv4 response 8.8.8.8')
+    end
+
+    it 'shows an error when the IP is invalid' do
+      expect(Whois::Client).to receive(:new) { ipv4_err }
+      send_command('whois 0.0.0.0')
+      expect(replies.last).to eq('Cannot find a WHOIS server for 0.0.0.0')
+    end
+
+    it 'shows results for the IPv6 address' do
+      expect(Whois::Client).to receive(:new) { ipv6_good }
+      send_command('whois 2001:418:141e:196::fc4')
+      expect(replies.last).to eq('IPv6 resp 2001:418:141e:196::fc4')
+    end
+
+    it 'shows an error when the IP is invalid' do
+      expect(Whois::Client).to receive(:new) { ipv6_err }
+      send_command('whois ::')
+      expect(replies.last).to eq('Cannot find a WHOIS server for ::')
+    end
+  end
 end

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -1,2 +1,10 @@
-require "lita-whois"
-require "lita/rspec"
+require 'simplecov'
+require 'coveralls'
+SimpleCov.formatter = SimpleCov::Formatter::MultiFormatter[
+    SimpleCov::Formatter::HTMLFormatter,
+    Coveralls::SimpleCov::Formatter
+]
+SimpleCov.start { add_filter '/spec/' }
+
+require 'lita-whois'
+require 'lita/rspec'


### PR DESCRIPTION
This plugin looked like it could use a little freshening up, so I've gone ahead and bumped it to use Lita 3.0, added all the right metadata, switched to using a pure-ruby library for WHOIS lookups, and added in test coverage.
