### PR TITLE
Change pessimistic version constraint

### DIFF
--- a/lita-whois.gemspec
+++ b/lita-whois.gemspec
@@ -14,7 +14,7 @@ Gem::Specification.new do |spec|
   spec.test_files    = spec.files.grep(%r{^(test|spec|features)/})
   spec.require_paths = ['lib']
 
-  spec.add_runtime_dependency 'lita', '~> 4.2'
+  spec.add_runtime_dependency 'lita', '>= 4.2'
   spec.add_runtime_dependency 'whois'
 
   spec.add_development_dependency 'bundler'


### PR DESCRIPTION
There's nothing about lita-whois that is incompatible with the current
master branch of litaio/lita (verified by running the lita-whois test
suite against it), so I propose removing the pessimistic constraint.
This would allow teams running the latest pre-release version of lita to
continue using lita-whois.
